### PR TITLE
feat: add start command (#72)

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -1,0 +1,26 @@
+const { error, ok } = require('../logger');
+
+const { providers } = require('../providers');
+const { providerArg } = require('../args');
+
+
+exports.command = 'start <name>';
+exports.desc = 'Start a microkernel vm that has been shutdown';
+
+exports.builder = yargs => {
+    yargs.options({
+        provider: providerArg
+    });
+};
+
+exports.handler = async argv => {
+    const { name, provider } = argv;
+
+    try {
+        await providers[provider].start(name);
+        ok(`${name} started`);
+    }
+    catch (e) {
+        error(e);
+    }
+};

--- a/lib/providers/hyperkit.js
+++ b/lib/providers/hyperkit.js
@@ -85,6 +85,10 @@ class Hyperkit {
         console.log(`ssh -i ${sshInfo.private_key} ${sshInfo.user}@${sshInfo.hostname} -p ${sshInfo.port} -o StrictHostKeyChecking=no`);
     }
 
+    async start(name) {
+        return new Error("HyperKit does not support VMs in a shutdown state. For running on Hyperkit, use $ slim run")
+    }
+
     async stop(name) {
         return this.delete(name);
     }

--- a/lib/providers/kvm.js
+++ b/lib/providers/kvm.js
@@ -69,6 +69,10 @@ class KVM {
         console.log(`ssh -i ${sshInfo.private_key} ${sshInfo.user}@${sshInfo.hostname} -p ${sshInfo.port} -o StrictHostKeyChecking=no`);
     }
 
+    async start(name) {
+        await this.exec(`start ${name}`);
+    }
+
     async delete(name) {
         await this.exec(`undefine ${name}`);
     }

--- a/lib/providers/virtualbox.js
+++ b/lib/providers/virtualbox.js
@@ -100,6 +100,9 @@ class VirtualBox {
         console.log(`ssh -i ${sshInfo.private_key} ${sshInfo.user}@${sshInfo.hostname} -p ${sshInfo.port} -o StrictHostKeyChecking=no`)
     }
 
+    async start(name) {
+        await vbox({start: true, vmname: name, syncs: [], verbose: true});
+    }
 
     async stop(name, force = false) {
         await vbox({ stopCmd: true, vmname: name, syncs: [], verbose: false }).catch(e => e);


### PR DESCRIPTION
Closes #72 

Notes:
- HyperKit cannot support a start command as we are only managing the process PID to control the state of the VM
- `start` on HyperKit would be the equivalent of `run`, but since commands/run.js has extra functionality, throw an error instead of trying to duplicate code in commands/start.js 
- KVM `start` will not work after `slim stop <vm> -p kvm` since this uses `destroy` instead of `shutdown`. See #75 to see remedy. KVM `start` will only work after unexpected shutdown